### PR TITLE
feat: restore bidirectional VTE processing with proper exit code propagation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,11 +236,12 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "gscreen"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
  "crossterm",
+ "libc",
  "portable-pty",
  "tokio",
  "vte",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ clap = { version = "4.4", features = ["derive"] }
 anyhow = "1.0"
 which = "6.0"
 vte = "0.13"
+libc = "0.2"

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -18,10 +18,10 @@
  */
 
 use anyhow::{Context, Result};
-use portable_pty::{CommandBuilder, PtyPair, PtySize};
+use portable_pty::{Child, CommandBuilder, PtyPair, PtySize};
 use std::collections::HashMap;
 
-pub fn create_pty_with_command(command: &str, args: &[String]) -> Result<PtyPair> {
+pub fn create_pty_with_command(command: &str, args: &[String]) -> Result<(PtyPair, Box<dyn Child>)> {
     // Create a new PTY with the actual terminal size
     let (cols, rows) = crossterm::terminal::size().unwrap_or((80, 24)); // fallback to 80x24 if detection fails
 
@@ -66,10 +66,10 @@ pub fn create_pty_with_command(command: &str, args: &[String]) -> Result<PtyPair
     }
 
     // Spawn the command in the PTY slave
-    let _child = pty_pair
+    let child = pty_pair
         .slave
         .spawn_command(cmd_builder)
         .context("Failed to spawn command in PTY")?;
 
-    Ok(pty_pair)
+    Ok((pty_pair, child))
 }


### PR DESCRIPTION
- Implement async non-blocking stdin handling to process terminal responses
- Restore InputVteHandler usage for bidirectional terminal communication
- Add child process monitoring to prevent hanging on commands without output
- Maintain proper exit code propagation to parent processes
- Support terminal capability queries, cursor position requests, and OSC sequences
- Fix hanging issues when running gscreen from other programs like
  vscode
